### PR TITLE
feat(Browser): Avialability to select port where webserver starts to listen up 

### DIFF
--- a/internal/cmd/connect/browser/browser.go
+++ b/internal/cmd/connect/browser/browser.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	insecureFlag  bool
-	webserverPort int
+	webserverPort int = GetFreeRandomPort(webserverPortRangeMin, webserverPortRangeMax)
 )
 
 func NewCommand() *cobra.Command {
@@ -197,9 +197,6 @@ func RunCommand(cmd *cobra.Command, args []string) {
 	}
 
 	// Define the local webserver proxy address
-	if webserverPort == 0 {
-		webserverPort = GetFreeRandomPort(webserverPortRangeMin, webserverPortRangeMax)
-	}
 	webserverAddress := fmt.Sprintf("127.0.0.1:%d", webserverPort)
 
 	// Define the URL of the target where the local webserver will attack

--- a/internal/cmd/connect/browser/browser.go
+++ b/internal/cmd/connect/browser/browser.go
@@ -35,7 +35,8 @@ const (
 )
 
 var (
-	insecureFlag bool
+	insecureFlag  bool
+	webserverPort int
 )
 
 func NewCommand() *cobra.Command {
@@ -49,6 +50,7 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&insecureFlag, "insecure", false, "Creates the local webserver without SSL/TLS")
+	cmd.Flags().IntVar(&webserverPort, "port", webserverPort, "Port for the local webserver where browser will connect")
 
 	return cmd
 }
@@ -195,7 +197,9 @@ func RunCommand(cmd *cobra.Command, args []string) {
 	}
 
 	// Define the local webserver proxy address
-	webserverPort := GetFreeRandomPort(webserverPortRangeMin, webserverPortRangeMax)
+	if webserverPort == 0 {
+		webserverPort = GetFreeRandomPort(webserverPortRangeMin, webserverPortRangeMax)
+	}
 	webserverAddress := fmt.Sprintf("127.0.0.1:%d", webserverPort)
 
 	// Define the URL of the target where the local webserver will attack

--- a/internal/cmd/connect/browser/templates.go
+++ b/internal/cmd/connect/browser/templates.go
@@ -18,7 +18,7 @@ const (
 	{Red}Impossible to get target ID from arguments.
 
 	{White}To connect to a target, you need to connect using {Cyan}Target ID {White}as follows:
-	{Bold}{White}console ~$ {Green}bbb connect browser {Cyan}{ttcp_example} [--insecure]`
+	{Bold}{White}console ~$ {Green}bbb connect browser {Cyan}{ttcp_example} [--insecure] [--port <port>]`
 
 	// AuthorizeSessionErrorMessage message is thrown when there is an error different from 4xx on authorize-session
 	// command execution

--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"bbb/internal/cmd/connect/browser"
 	"bbb/internal/cmd/connect/kube"
 	"bbb/internal/cmd/connect/ssh"
-	"bbb/internal/cmd/connect/browser"
 )
 
 const (


### PR DESCRIPTION
This PR avoids problems with Kibana dev tools history, so the webserver starts always on the port that user selects.

It's simple, but i think it is useful :D 