### PR TITLE
feat(Redis): Added redis scope to open boundary connections

### DIFF
--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -7,6 +7,7 @@ import (
 
 	"bbb/internal/cmd/connect/browser"
 	"bbb/internal/cmd/connect/kube"
+	"bbb/internal/cmd/connect/redis"
 	"bbb/internal/cmd/connect/ssh"
 	"bbb/internal/fancy"
 	"bbb/internal/globals"
@@ -32,6 +33,7 @@ func NewCommand() *cobra.Command {
 		kube.NewCommand(),
 		ssh.NewCommand(),
 		browser.NewCommand(),
+		redis.NewCommand(),
 	)
 
 	return c

--- a/internal/cmd/connect/redis/redis.go
+++ b/internal/cmd/connect/redis/redis.go
@@ -1,0 +1,206 @@
+package redis
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"bbb/internal/boundary"
+	"bbb/internal/fancy"
+	"bbb/internal/globals"
+
+	"net/url"
+)
+
+const (
+	descriptionShort = `Create a connection to a Redis target`
+	descriptionLong  = `
+	Create a connection to a Redis target.
+	It authorizes a session if needed, and open a redis-cli using it`
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "redis",
+		DisableFlagsInUseLine: true,
+		Short:                 descriptionShort,
+		Long:                  strings.ReplaceAll(descriptionLong, "\t", ""),
+
+		Run: RunCommand,
+	}
+
+	return cmd
+}
+
+// RunCommand TODO
+// Ref: https://pkg.go.dev/github.com/spf13/pflag#StringSlice
+func RunCommand(cmd *cobra.Command, args []string) {
+
+	var err error
+	var consoleStderr bytes.Buffer
+	var consoleStdout bytes.Buffer
+
+	//
+	storedTokenReference, err := globals.GetStoredTokenReference()
+	if err != nil {
+		fancy.Fatalf(globals.TokenRetrievalErrorMessage)
+	}
+
+	// We need a target to connect to
+	if len(args) != 1 {
+		fancy.Fatalf(CommandArgsNoTargetErrorMessage)
+	}
+
+	// Redis-cli package used to open the connection
+	var redisCli string = "redis-cli"
+
+	// Check if redis-cli is present in the system, if not, just return the connection to the user
+	var redisCliPresent bool = true
+
+	_, err = exec.LookPath(redisCli)
+	if err != nil {
+		fancy.Printf(RedisCliNotFoundErrorMessage)
+		redisCliPresent = false
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// 1. Ask H.Boundary for an authorized session
+	// This request will provide a session ID and brokered credentials associated to the target
+	// (AuthorizeSession & Connect) are performed in separated steps to check type of target before connecting
+	_, err = boundary.GetTargetAuthorizedSession(storedTokenReference, args[0], &consoleStdout, &consoleStderr)
+	if err != nil {
+		// Brutally fail when there is no output or error to handle anything
+		if len(consoleStderr.Bytes()) == 0 && len(consoleStdout.Bytes()) == 0 {
+			fancy.Fatalf(AuthorizeSessionErrorMessage, err.Error(), consoleStderr.String())
+		}
+
+		// Forward stderr to stdout for later processing
+		consoleStdout = consoleStderr
+	}
+
+	//
+	var response boundary.AuthorizeSessionResponseT
+	err = json.Unmarshal(consoleStdout.Bytes(), &response)
+	if err != nil {
+		fancy.Fatalf(globals.UnexpectedErrorMessage, "Failed converting JSON object into Struct: "+err.Error())
+	}
+
+	// On user failures, just inform the user
+	if response.StatusCode >= 400 && response.StatusCode < 500 {
+		fancy.Fatalf(AuthorizeSessionUserErrorMessage, consoleStdout.String())
+	}
+
+	if len(response.Item.Credentials) == 0 {
+		fancy.Printf(TargetWithNoCredentials)
+	}
+
+	//
+	targetSessionToken := response.Item.AuthorizationToken
+
+	// Extract host of the target in Boundary for later usage.
+	// Remember some proxies use this to route
+	targetSessionUrl, err := url.Parse(response.Item.Endpoint)
+	if err != nil {
+		fancy.Fatalf(globals.UnexpectedErrorMessage,
+			"Failed parsing session URL. You have to configure a valid URL in Boundary: "+err.Error())
+	}
+
+	//
+	targetSessionHost := strings.Split(targetSessionUrl.Host, ":")
+	if len(targetSessionHost) != 2 {
+		fancy.Fatalf(globals.UnexpectedErrorMessage,
+			"Failed parsing session Host. Session URL must have <address>:<port> format: "+err.Error())
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// 2. Create a TCP connection to the target with authorized session previously created
+	// User commands will be performed over this connection
+	sessionFileName := targetSessionToken[:10]
+	connectCommand, err := boundary.GetSessionConnection(storedTokenReference, targetSessionToken)
+	if err != nil {
+		fancy.Fatalf(globals.UnexpectedErrorMessage,
+			"Failed executing 'boundary connect' command: "+err.Error()+"\nCommand stderr: "+consoleStderr.String())
+	}
+
+	//
+	stdoutFile := globals.BbbTemporaryDir + "/" + sessionFileName + ".out"
+	connectSessionStdoutRaw, err := globals.GetFileContents(stdoutFile, true)
+	if err != nil {
+		fancy.Fatalf(globals.UnexpectedErrorMessage, err.Error())
+	}
+
+	//
+	var connectSessionStdout boundary.ConnectSessionStdoutT
+	err = json.Unmarshal(connectSessionStdoutRaw, &connectSessionStdout)
+	if err != nil {
+		fancy.Fatalf(globals.UnexpectedErrorMessage, "Failed converting JSON object into Struct: "+err.Error())
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// 3. Open redis-cli to the socket opened by the connection
+	// We use redis-cli or just return the connection to the user
+
+	// Redis URL to connect to
+	redisUrl := fmt.Sprintf("redis://%s:%d", connectSessionStdout.Address, connectSessionStdout.Port)
+
+	// Redis-cli arguments for authentication if needed
+	redisCliArgs := []string{"-u", redisUrl}
+
+	// Use password/access key to the cli command
+	if response.Item.Credentials[0].Credential.Password != "" {
+		redisCliArgs = append(redisCliArgs,
+			"--pass", response.Item.Credentials[0].Credential.Password)
+	}
+
+	// Boundary does not allow to define password and not an username
+	// As workaround, we set in boundary username and password to the same value
+	// rescued from Vault
+	if response.Item.Credentials[0].Credential.Username != "" &&
+		response.Item.Credentials[0].Credential.Username != response.Item.Credentials[0].Credential.Password {
+		redisCliArgs = append(redisCliArgs,
+			"--user", response.Item.Credentials[0].Credential.Username)
+	}
+
+	// Set redis-cli command
+	redisCommand := exec.Command(redisCli, redisCliArgs...)
+
+	redisCommand.Stdin = os.Stdin
+	redisCommand.Stdout = os.Stdout
+	redisCommand.Stderr = &consoleStderr
+
+	durationStringFromNow, err := globals.GetDurationStringFromNow(connectSessionStdout.Expiration)
+	if err != nil {
+		fancy.Fatalf(globals.UnexpectedErrorMessage, "Error getting session duration: "+err.Error())
+	}
+
+	fancy.Printf(ConnectionSuccessfulMessage,
+		connectSessionStdout.SessionId,
+		durationStringFromNow,
+		redisUrl)
+
+	// If redis-cli is not present, just return the connection to the user
+	if redisCliPresent {
+		err = redisCommand.Run()
+
+		if err != nil {
+			fancy.Fatalf(globals.UnexpectedErrorMessage,
+				"Failed executing '"+redisCli+"' command: "+err.Error()+"\nCommand stderr: "+consoleStderr.String())
+		}
+	} else {
+		// If redis-cli is not present, just return the connection to the user and wait
+		// for the user to close the connection manually with Cntrl+C
+		WaitSignal()
+	}
+
+	// Clean up the connection
+	err = connectCommand.Process.Kill()
+	if err != nil {
+		fancy.Fatalf(globals.UnexpectedErrorMessage,
+			"\nFailed killing background connection to H.Boundary: %v\n", err)
+	}
+}

--- a/internal/cmd/connect/redis/redis.go
+++ b/internal/cmd/connect/redis/redis.go
@@ -59,13 +59,10 @@ func RunCommand(cmd *cobra.Command, args []string) {
 	// Redis-cli package used to open the connection
 	var redisCli string = "redis-cli"
 
-	// Check if redis-cli is present in the system, if not, just return the connection to the user
-	var redisCliPresent bool = true
-
+	// Check if redis-cli is present in the system, if not, exit with error
 	_, err = exec.LookPath(redisCli)
 	if err != nil {
-		fancy.Printf(RedisCliNotFoundErrorMessage)
-		redisCliPresent = false
+		fancy.Fatalf(RedisCliNotFoundErrorMessage)
 	}
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -183,18 +180,11 @@ func RunCommand(cmd *cobra.Command, args []string) {
 		durationStringFromNow,
 		redisUrl)
 
-	// If redis-cli is not present, just return the connection to the user
-	if redisCliPresent {
-		err = redisCommand.Run()
+	err = redisCommand.Run()
 
-		if err != nil {
-			fancy.Fatalf(globals.UnexpectedErrorMessage,
-				"Failed executing '"+redisCli+"' command: "+err.Error()+"\nCommand stderr: "+consoleStderr.String())
-		}
-	} else {
-		// If redis-cli is not present, just return the connection to the user and wait
-		// for the user to close the connection manually with Cntrl+C
-		WaitSignal()
+	if err != nil {
+		fancy.Fatalf(globals.UnexpectedErrorMessage,
+			"Failed executing '"+redisCli+"' command: "+err.Error()+"\nCommand stderr: "+consoleStderr.String())
 	}
 
 	// Clean up the connection

--- a/internal/cmd/connect/redis/templates.go
+++ b/internal/cmd/connect/redis/templates.go
@@ -12,7 +12,7 @@ const (
 	{White}For Linux users: {Reset}{Cyan}Use your package manager and install 'redis'
 	{White}For MacOS users: {Reset}{Cyan}Use your package manager and install 'redis'
 
-	{White}Anyways, we will create the connection and we will not open redis-cli for you :(`
+	{White}Install redis-cli and try again if you want ;)`
 
 	// CommandArgsNoTargetErrorMessage is the message thrown when the user is trying to establish a connection
 	// without defining a target
@@ -66,6 +66,6 @@ const (
 
 	{Magenta}Your redis CLI will automatically open pointing to desired URL.
 	If redis-cli does not open automatically, probably you don't have the package installed
-	Just install it or open the conenction manually to the following URL{Reset}
+	Just install it and try again{Reset}
 	{Bold}{White}Redis listening on: {Green}%s`
 )

--- a/internal/cmd/connect/redis/templates.go
+++ b/internal/cmd/connect/redis/templates.go
@@ -1,0 +1,71 @@
+package redis
+
+const (
+	RedisCliNotFoundErrorMessage = `
+	{Red}The package redis-cli is not detected on your system.
+
+	{Magenta}If you want to open a connection directly to a Redis target,
+	you need to have redis-cli installed on your system.
+
+	{White}It is possible to remediate this issue installing it from:
+
+	{White}For Linux users: {Reset}{Cyan}Use your package manager and install 'redis'
+	{White}For MacOS users: {Reset}{Cyan}Use your package manager and install 'redis'
+
+	{White}Anyways, we will create the connection and we will not open redis-cli for you :(`
+
+	// CommandArgsNoTargetErrorMessage is the message thrown when the user is trying to establish a connection
+	// without defining a target
+	CommandArgsNoTargetErrorMessage = `
+	{Red}Impossible to get target ID from arguments.
+
+	{White}To connect to a target, you need to connect using {Cyan}Target ID {White}as follows:
+	{Bold}{White}console ~$ {Green}bbb connect redis {Cyan}{ttcp_example}`
+
+	// AuthorizeSessionErrorMessage message is thrown when there is an error different from 4xx on authorize-session
+	// command execution
+	AuthorizeSessionErrorMessage = `
+	{Red}Error executing 'authorize-session' command.
+
+	{White}Command execution returned:
+	{Italic}%s{Reset}
+
+	{White}H.Boundary command under the hood returned:
+	{Italic}%s`
+
+	// AuthorizeSessionUserErrorMessage message is thrown when there is a 4xx error on authorize-session command execution
+	AuthorizeSessionUserErrorMessage = `
+	{Red}There is something wrong with your target when authorizing the session
+
+	{Magenta}Review following points:
+	* Your H.Boundary token is still valid
+	* You have properly written the target id
+	* You have enough permissions to authorize a session against to that target
+
+	{White}Under the hood:
+	{Italic}%s`
+
+	//
+	TargetWithNoCredentials = `
+	{Magenta}Selected target has no credentials associated.
+
+	Anyways we will try to connect to your target with no credentials, but it may fail.`
+
+	// ConnectionSuccessfulMessage represents the message thrown when everything finished as expected
+	// and shows how to use recently created (connection + webserver) to the user
+	ConnectionSuccessfulMessage = `
+	{Magenta}Some reminders: {Reset}
+
+	* Your H.Boundary session ID is: {Bold}{Cyan}%s {Reset}
+	* Your session will expire in: {Bold}{Cyan}%s {Reset}
+
+
+	Press following combination to kill the connection once you don't need it:
+	{Bold}{White}console ~$ {Green}Cntrl + C {Reset}
+
+
+	{Magenta}Your redis CLI will automatically open pointing to desired URL.
+	If redis-cli does not open automatically, probably you don't have the package installed
+	Just install it or open the conenction manually to the following URL{Reset}
+	{Bold}{White}Redis listening on: {Green}%s`
+)

--- a/internal/cmd/connect/redis/utils.go
+++ b/internal/cmd/connect/redis/utils.go
@@ -1,0 +1,23 @@
+package redis
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// WaitSignalAfter waits for a signal to close the process gracefully
+// after executing a callback function
+func WaitSignal() {
+
+	// Capture some OS signals to close the process gracefully before closing
+	SignalsToReceive := []os.Signal{
+		syscall.SIGTERM, syscall.SIGINT, // Ctrl+C
+		syscall.SIGTSTP, // Ctrl+Z
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, SignalsToReceive...)
+
+	<-c
+}

--- a/internal/cmd/list/templates.go
+++ b/internal/cmd/list/templates.go
@@ -18,9 +18,10 @@ const (
 	{Bold}{White}console ~$ {Green}bbb connect ssh {Cyan}{ttcp_example} {Reset}
 	{Bold}{White}console ~$ {Green}bbb connect kube {Cyan}{ttcp_example} {Reset}
 	{Bold}{White}console ~$ {Green}bbb connect browser {Cyan}{ttcp_example} [--insecure]{Reset}
+	{Bold}{White}console ~$ {Green}bbb connect redis {Cyan}{ttcp_example}{Reset}
 
-	Remember to use {Bold}{Cyan}ssh{Reset}, {Bold}{Cyan}kube{Reset} or {Bold}{Cyan}browser{Reset} subcommand
-	depending on the target you are trying to connect to.`
+	Remember to use {Bold}{Cyan}ssh{Reset}, {Bold}{Cyan}kube{Reset}, {Bold}{Cyan}browser{Reset}
+	or {Bold}{Cyan}redis{Reset} subcommand depending on the target you are trying to connect to.`
 
 	//
 	ListCommandEmpty = `


### PR DESCRIPTION
### Notes
* Now you can execute `bbb connect redis <target>` and if you have `redis-cli` package installed into the system, bbb automatically open to you a session with that CLI. If not, just open the connection and wait until user kill it.
* For authentication, you can use just an password (access-key), username+password (Until redis 6, redis supports ACLs) and nothing. Bbb will try any option, but we develop a workaround for just password authentication.
  

> Boundary does not allow targets with just the password configured, so as workaround we can configure username = password in boundary and the authorize session starts to work.

### Contributors
@dfradehubs 